### PR TITLE
Add tests for Generate SBOM Task

### DIFF
--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
@@ -26,28 +26,28 @@ public abstract class AbstractGenerateSbomTaskTests
 {
     internal abstract SbomSpecification SbomSpecification { get; }
 
-    private static readonly string CurrentDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-    private static readonly string DefaultManifestDirectory = Path.Combine(CurrentDirectory, "_manifest");
-    private static readonly string TemporaryDirectory = Path.Combine(CurrentDirectory, "_temp");
-    private const string PackageSupplier = "Test-Microsoft";
-    private const string PackageName = "CoseSignTool";
-    private const string PackageVersion = "0.0.1";
-    private const string NamespaceBaseUri = "https://base0.uri";
+    internal static readonly string CurrentDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+    internal static readonly string DefaultManifestDirectory = Path.Combine(CurrentDirectory, "_manifest");
+    internal static readonly string TemporaryDirectory = Path.Combine(CurrentDirectory, "_temp");
+    internal const string PackageSupplier = "Test-Microsoft";
+    internal const string PackageName = "CoseSignTool";
+    internal const string PackageVersion = "0.0.1";
+    internal const string NamespaceBaseUri = "https://base0.uri";
 
-    private Mock<IBuildEngine> buildEngine;
-    private List<BuildErrorEventArgs> errors;
-    private string manifestPath;
-    private GeneratedSbomValidator generatedSbomValidator;
+    internal Mock<IBuildEngine> BuildEngine;
+    internal List<BuildErrorEventArgs> Errors;
+    internal string ManifestPath;
+    internal GeneratedSbomValidator GeneratedSbomValidator;
 
-    private string SbomSpecificationDirectoryName => $"{this.SbomSpecification.Name}_{this.SbomSpecification.Version}";
+    internal string SbomSpecificationDirectoryName => $"{this.SbomSpecification.Name}_{this.SbomSpecification.Version}";
 
     [TestInitialize]
     public void Startup()
     {
         // Setup the build engine
-        this.buildEngine = new Mock<IBuildEngine>();
-        this.errors = new List<BuildErrorEventArgs>();
-        this.buildEngine.Setup(x => x.LogErrorEvent(It.IsAny<BuildErrorEventArgs>())).Callback<BuildErrorEventArgs>(e => errors.Add(e));
+        this.BuildEngine = new Mock<IBuildEngine>();
+        this.Errors = new List<BuildErrorEventArgs>();
+        this.BuildEngine.Setup(x => x.LogErrorEvent(It.IsAny<BuildErrorEventArgs>())).Callback<BuildErrorEventArgs>(e => Errors.Add(e));
 
         // Clean up the manifest directory
         if (Directory.Exists(DefaultManifestDirectory))
@@ -61,8 +61,8 @@ public abstract class AbstractGenerateSbomTaskTests
             Directory.Delete(TemporaryDirectory, true);
         }
 
-        this.manifestPath = Path.Combine(DefaultManifestDirectory, this.SbomSpecificationDirectoryName, "manifest.spdx.json");
-        this.generatedSbomValidator = new(this.SbomSpecification);
+        this.ManifestPath = Path.Combine(DefaultManifestDirectory, this.SbomSpecificationDirectoryName, "manifest.spdx.json");
+        this.GeneratedSbomValidator = new(this.SbomSpecification);
     }
 
     [TestMethod]
@@ -76,7 +76,7 @@ public abstract class AbstractGenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object,
+            BuildEngine = this.BuildEngine.Object,
             ManifestInfo = this.SbomSpecification.ToString(),
         };
 
@@ -85,7 +85,7 @@ public abstract class AbstractGenerateSbomTaskTests
 
         // Assert
         Assert.IsTrue(result);
-        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri);
+        this.GeneratedSbomValidator.AssertSbomIsValid(this.ManifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri);
     }
 
     [TestMethod]
@@ -102,7 +102,7 @@ public abstract class AbstractGenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object,
+            BuildEngine = this.BuildEngine.Object,
             ManifestInfo = this.SbomSpecification.ToString(),
         };
 
@@ -112,8 +112,8 @@ public abstract class AbstractGenerateSbomTaskTests
         // Assert
         Assert.IsTrue(result);
 
-        this.manifestPath = Path.Combine(manifestDirPath, "_manifest", this.SbomSpecificationDirectoryName, "manifest.spdx.json");
-        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri);
+        this.ManifestPath = Path.Combine(manifestDirPath, "_manifest", this.SbomSpecificationDirectoryName, "manifest.spdx.json");
+        this.GeneratedSbomValidator.AssertSbomIsValid(this.ManifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri);
     }
 
     [TestMethod]
@@ -127,7 +127,7 @@ public abstract class AbstractGenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object,
+            BuildEngine = this.BuildEngine.Object,
             ManifestInfo = this.SbomSpecification.ToString(),
         };
 
@@ -150,7 +150,7 @@ public abstract class AbstractGenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object,
+            BuildEngine = this.BuildEngine.Object,
             ManifestInfo = this.SbomSpecification.ToString(),
         };
 
@@ -174,7 +174,7 @@ public abstract class AbstractGenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object,
+            BuildEngine = this.BuildEngine.Object,
             ManifestInfo = this.SbomSpecification.ToString(),
         };
 
@@ -198,7 +198,7 @@ public abstract class AbstractGenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object,
+            BuildEngine = this.BuildEngine.Object,
             ManifestInfo = this.SbomSpecification.ToString(),
         };
 
@@ -225,7 +225,7 @@ public abstract class AbstractGenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object,
+            BuildEngine = this.BuildEngine.Object,
             ManifestInfo = this.SbomSpecification.ToString(),
         };
 
@@ -234,7 +234,7 @@ public abstract class AbstractGenerateSbomTaskTests
 
         // Assert
         Assert.IsTrue(result);
-        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri, buildComponentPath: sourceDirectory);
+        this.GeneratedSbomValidator.AssertSbomIsValid(this.ManifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri, buildComponentPath: sourceDirectory);
     }
 
     [TestMethod]
@@ -250,7 +250,7 @@ public abstract class AbstractGenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             NamespaceUriUniquePart = uniqueNamespacePart,
-            BuildEngine = this.buildEngine.Object,
+            BuildEngine = this.BuildEngine.Object,
             ManifestInfo = this.SbomSpecification.ToString(),
         };
 
@@ -259,6 +259,6 @@ public abstract class AbstractGenerateSbomTaskTests
 
         // Assert
         Assert.IsTrue(result);
-        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri, expectedNamespaceUriUniquePart: uniqueNamespacePart);
+        this.GeneratedSbomValidator.AssertSbomIsValid(this.ManifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri, expectedNamespaceUriUniquePart: uniqueNamespacePart);
     }
 }

--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
@@ -29,7 +29,7 @@ public abstract class AbstractGenerateSbomTaskTests
     private static readonly string CurrentDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
     private static readonly string DefaultManifestDirectory = Path.Combine(CurrentDirectory, "_manifest");
     private static readonly string TemporaryDirectory = Path.Combine(CurrentDirectory, "_temp");
-    private const string PackageSuplier = "Test-Microsoft";
+    private const string PackageSupplier = "Test-Microsoft";
     private const string PackageName = "CoseSignTool";
     private const string PackageVersion = "0.0.1";
     private const string NamespaceBaseUri = "https://base0.uri";
@@ -72,7 +72,7 @@ public abstract class AbstractGenerateSbomTaskTests
         var task = new GenerateSbomTask
         {
             BuildDropPath = CurrentDirectory,
-            PackageSupplier = PackageSuplier,
+            PackageSupplier = PackageSupplier,
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
@@ -85,7 +85,7 @@ public abstract class AbstractGenerateSbomTaskTests
 
         // Assert
         Assert.IsTrue(result);
-        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSuplier, NamespaceBaseUri);
+        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri);
     }
 
     [TestMethod]
@@ -98,7 +98,7 @@ public abstract class AbstractGenerateSbomTaskTests
         {
             BuildDropPath = CurrentDirectory,
             ManifestDirPath = manifestDirPath,
-            PackageSupplier = PackageSuplier,
+            PackageSupplier = PackageSupplier,
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
@@ -113,7 +113,7 @@ public abstract class AbstractGenerateSbomTaskTests
         Assert.IsTrue(result);
 
         this.manifestPath = Path.Combine(manifestDirPath, "_manifest", this.SbomSpecificationDirectoryName, "manifest.spdx.json");
-        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSuplier, NamespaceBaseUri);
+        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri);
     }
 
     [TestMethod]
@@ -123,7 +123,7 @@ public abstract class AbstractGenerateSbomTaskTests
         var task = new GenerateSbomTask
         {
             BuildDropPath = ".\\non-existent\\path",
-            PackageSupplier = PackageSuplier,
+            PackageSupplier = PackageSupplier,
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
@@ -146,7 +146,7 @@ public abstract class AbstractGenerateSbomTaskTests
         {
             BuildDropPath = CurrentDirectory,
             BuildComponentPath = ".\\non-existent\\path",
-            PackageSupplier = PackageSuplier,
+            PackageSupplier = PackageSupplier,
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
@@ -170,7 +170,7 @@ public abstract class AbstractGenerateSbomTaskTests
         {
             BuildDropPath = CurrentDirectory,
             ExternalDocumentListFile = ".\\non-existent\\path",
-            PackageSupplier = PackageSuplier,
+            PackageSupplier = PackageSupplier,
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
@@ -194,7 +194,7 @@ public abstract class AbstractGenerateSbomTaskTests
         {
             BuildDropPath = CurrentDirectory,
             ManifestDirPath = ".\\non-existent\\path",
-            PackageSupplier = PackageSuplier,
+            PackageSupplier = PackageSupplier,
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
@@ -221,7 +221,7 @@ public abstract class AbstractGenerateSbomTaskTests
         {
             BuildDropPath = CurrentDirectory,
             BuildComponentPath = sourceDirectory,
-            PackageSupplier = PackageSuplier,
+            PackageSupplier = PackageSupplier,
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
@@ -234,7 +234,7 @@ public abstract class AbstractGenerateSbomTaskTests
 
         // Assert
         Assert.IsTrue(result);
-        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSuplier, NamespaceBaseUri, buildComponentPath: sourceDirectory);
+        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri, buildComponentPath: sourceDirectory);
     }
 
     [TestMethod]
@@ -245,7 +245,7 @@ public abstract class AbstractGenerateSbomTaskTests
         var task = new GenerateSbomTask
         {
             BuildDropPath = CurrentDirectory,
-            PackageSupplier = PackageSuplier,
+            PackageSupplier = PackageSupplier,
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
@@ -259,6 +259,6 @@ public abstract class AbstractGenerateSbomTaskTests
 
         // Assert
         Assert.IsTrue(result);
-        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSuplier, NamespaceBaseUri, expectedNamespaceUriUniquePart: uniqueNamespacePart);
+        this.generatedSbomValidator.AssertSbomIsValid(this.manifestPath, CurrentDirectory, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri, expectedNamespaceUriUniquePart: uniqueNamespacePart);
     }
 }

--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Sbom.Targets.Tests;
 [TestClass]
 public abstract class AbstractGenerateSbomTaskTests
 {
-    internal SbomSpecification SbomSpecification;
+    internal abstract SbomSpecification SbomSpecification { get; }
 
     private static readonly string CurrentDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
     private static readonly string DefaultManifestDirectory = Path.Combine(CurrentDirectory, "_manifest");

--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
@@ -18,9 +18,14 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Sbom.Targets.Tests;
 
+/// <summary>
+/// Base class for testing SBOM generation through the GenerateSbomTask.
+/// </summary>
 [TestClass]
-public class GenerateSbomTaskTests
+public abstract class AbstractGenerateSbomTaskTests
 {
+    internal SbomSpecification SbomSpecification;
+
     private static readonly string CurrentDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
     private static readonly string DefaultManifestDirectory = Path.Combine(CurrentDirectory, "_manifest");
     private static readonly string TemporaryDirectory = Path.Combine(CurrentDirectory, "_temp");
@@ -32,15 +37,9 @@ public class GenerateSbomTaskTests
     private Mock<IBuildEngine> buildEngine;
     private List<BuildErrorEventArgs> errors;
     private string manifestPath;
-    private SbomSpecification sbomSpecification;
     private GeneratedSbomValidator generatedSbomValidator;
 
-    private string SbomSpecificationDirectoryName => $"{this.sbomSpecification.Name}_{this.sbomSpecification.Version}";
-
-    public GenerateSbomTaskTests()
-    {
-        this.sbomSpecification = Constants.SPDX22Specification;
-    }
+    private string SbomSpecificationDirectoryName => $"{this.SbomSpecification.Name}_{this.SbomSpecification.Version}";
 
     [TestInitialize]
     public void Startup()
@@ -63,7 +62,7 @@ public class GenerateSbomTaskTests
         }
 
         this.manifestPath = Path.Combine(DefaultManifestDirectory, this.SbomSpecificationDirectoryName, "manifest.spdx.json");
-        this.generatedSbomValidator = new(this.sbomSpecification);
+        this.generatedSbomValidator = new(this.SbomSpecification);
     }
 
     [TestMethod]
@@ -78,7 +77,7 @@ public class GenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             BuildEngine = this.buildEngine.Object,
-            ManifestInfo = this.sbomSpecification.ToString(),
+            ManifestInfo = this.SbomSpecification.ToString(),
         };
 
         // Act
@@ -104,7 +103,7 @@ public class GenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             BuildEngine = this.buildEngine.Object,
-            ManifestInfo = this.sbomSpecification.ToString(),
+            ManifestInfo = this.SbomSpecification.ToString(),
         };
 
         // Act
@@ -129,7 +128,7 @@ public class GenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             BuildEngine = this.buildEngine.Object,
-            ManifestInfo = this.sbomSpecification.ToString(),
+            ManifestInfo = this.SbomSpecification.ToString(),
         };
 
         // Act
@@ -152,7 +151,7 @@ public class GenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             BuildEngine = this.buildEngine.Object,
-            ManifestInfo = this.sbomSpecification.ToString(),
+            ManifestInfo = this.SbomSpecification.ToString(),
         };
 
         // Act
@@ -176,7 +175,7 @@ public class GenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             BuildEngine = this.buildEngine.Object,
-            ManifestInfo = this.sbomSpecification.ToString(),
+            ManifestInfo = this.SbomSpecification.ToString(),
         };
 
         // Act
@@ -200,7 +199,7 @@ public class GenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             BuildEngine = this.buildEngine.Object,
-            ManifestInfo = this.sbomSpecification.ToString(),
+            ManifestInfo = this.SbomSpecification.ToString(),
         };
 
         // Act
@@ -227,7 +226,7 @@ public class GenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             BuildEngine = this.buildEngine.Object,
-            ManifestInfo = this.sbomSpecification.ToString(),
+            ManifestInfo = this.SbomSpecification.ToString(),
         };
 
         // Act
@@ -252,7 +251,7 @@ public class GenerateSbomTaskTests
             NamespaceBaseUri = NamespaceBaseUri,
             NamespaceUriUniquePart = uniqueNamespacePart,
             BuildEngine = this.buildEngine.Object,
-            ManifestInfo = this.sbomSpecification.ToString(),
+            ManifestInfo = this.SbomSpecification.ToString(),
         };
 
         // Act

--- a/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskSPDX_2_2Tests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskSPDX_2_2Tests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Targets.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Class to test the generation of SBOM using SPDX 2.2 specification.
+/// </summary>
+[TestClass]
+public class GenerateSbomTaskSPDX_2_2Tests : AbstractGenerateSbomTaskTests
+{
+    public GenerateSbomTaskSPDX_2_2Tests()
+    {
+        this.SbomSpecification = Constants.SPDX22Specification;
+    }
+}

--- a/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskSPDX_2_2Tests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskSPDX_2_2Tests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Utils;
+using Microsoft.Sbom.Contracts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
@@ -17,8 +18,5 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class GenerateSbomTaskSPDX_2_2Tests : AbstractGenerateSbomTaskTests
 {
-    public GenerateSbomTaskSPDX_2_2Tests()
-    {
-        this.SbomSpecification = Constants.SPDX22Specification;
-    }
+    internal override SbomSpecification SbomSpecification => Constants.SPDX22Specification;
 }

--- a/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskTests.cs
@@ -8,16 +8,24 @@ using Microsoft.Build.Framework;
 using Microsoft.Sbom.Targets;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json;
 
 namespace Microsoft.Sbom.Targets.Tests;
 
 [TestClass]
 public class GenerateSbomTaskTests
 {
-    private Mock<IBuildEngine> buildEngine;
-    private List<BuildErrorEventArgs> errors;
     private static readonly string CurrentDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
     private static readonly string ManifestDirectory = Path.Combine(CurrentDirectory, "_manifest");
+    private static readonly string TemporaryDirectory = Path.Combine(CurrentDirectory, "_temp");
+    private static readonly string ManifestPath = Path.Combine(ManifestDirectory, "spdx_2.2", "manifest.spdx.json");
+    private const string PackageSuplier = "Test-Microsoft";
+    private const string PackageName = "CoseSignTool";
+    private const string PackageVersion = "0.0.1";
+    private const string NamespaceBaseUri = "https://base0.uri";
+
+    private Mock<IBuildEngine> buildEngine;
+    private List<BuildErrorEventArgs> errors;
 
     [TestInitialize]
     public void Startup()
@@ -34,21 +42,78 @@ public class GenerateSbomTaskTests
         }
     }
 
+    [TestCleanup]
+    public void Cleanup()
+    {
+        // Clean up the manifest directory
+        if (Directory.Exists(TemporaryDirectory))
+        {
+            Directory.Delete(TemporaryDirectory, true);
+        }
+    }
+
     [TestMethod]
     public void Sbom_Is_Successfully_Generated()
     {
-        // Let's generate a SBOM for the current assembly
-        var sourceDirectory = Path.Combine(CurrentDirectory, "..\\..\\..");
-
         // Arrange
         var task = new GenerateSbomTask
         {
             BuildDropPath = CurrentDirectory,
-            BuildComponentPath = sourceDirectory,
-            PackageSupplier = "Microsoft",
-            PackageName = "CoseSignTool",
-            PackageVersion = "1.0.0",
-            NamespaceBaseUri = "https://base.uri",
+            PackageSupplier = PackageSuplier,
+            PackageName = PackageName,
+            PackageVersion = PackageVersion,
+            NamespaceBaseUri = NamespaceBaseUri,
+            BuildEngine = this.buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        Assert.IsTrue(result);
+        Assert.IsTrue(File.Exists(ManifestPath));
+
+        // Read and parse the manifest
+        var manifestContent = File.ReadAllText(ManifestPath);
+        var manifest = JsonConvert.DeserializeObject<dynamic>(manifestContent);
+
+        // Check the manifest has expected values
+        var filesValue = manifest["files"];
+        Assert.IsNotNull(filesValue);
+        Assert.IsTrue(filesValue.Count > 0);
+
+        var packagesValue = manifest["packages"];
+        Assert.IsNotNull(packagesValue);
+        Assert.IsTrue(packagesValue.Count == 1);
+
+        var nameValue = manifest["name"];
+        Assert.IsNotNull(nameValue);
+        Assert.AreEqual($"{PackageName} {PackageVersion}", (string)nameValue);
+
+        var creatorsValue = manifest["creationInfo"]["creators"];
+        Assert.IsNotNull(creatorsValue);
+        Assert.IsTrue(creatorsValue.Count > 0);
+        Assert.IsTrue(((string)creatorsValue[0]).Contains(PackageSuplier));
+
+        string namespaceValue = manifest["documentNamespace"];
+        Assert.IsNotNull(namespaceValue);
+        Assert.IsTrue(namespaceValue.Contains($"{NamespaceBaseUri}/{PackageName}/{PackageVersion}"));
+    }
+
+    [TestMethod]
+    public void Sbom_Is_Successfully_Generated_In_Specified_Location()
+    {
+        var manifestDirPath = Path.Combine(TemporaryDirectory, "sub-directory");
+        Directory.CreateDirectory(manifestDirPath);
+        // Arrange
+        var task = new GenerateSbomTask
+        {
+            BuildDropPath = CurrentDirectory,
+            ManifestDirPath = manifestDirPath,
+            PackageSupplier = PackageSuplier,
+            PackageName = PackageName,
+            PackageVersion = PackageVersion,
+            NamespaceBaseUri = NamespaceBaseUri,
             BuildEngine = this.buildEngine.Object
         };
 
@@ -58,7 +123,225 @@ public class GenerateSbomTaskTests
         // Assert
         Assert.IsTrue(result);
 
-        var manifestPath = Path.Combine(ManifestDirectory, "spdx_2.2", "manifest.spdx.json");
-        Assert.IsTrue(Path.Exists(manifestPath));
+        var manifestPath = Path.Combine(manifestDirPath, "_manifest", "spdx_2.2", "manifest.spdx.json");
+        Assert.IsTrue(File.Exists(manifestPath));
+
+        // Read and parse the manifest
+        var manifestContent = File.ReadAllText(manifestPath);
+        var manifest = JsonConvert.DeserializeObject<dynamic>(manifestContent);
+
+        // Check the manifest has expected values
+        var filesValue = manifest["files"];
+        Assert.IsNotNull(filesValue);
+        Assert.IsTrue(filesValue.Count > 0);
+
+        var packagesValue = manifest["packages"];
+        Assert.IsNotNull(packagesValue);
+        Assert.IsTrue(packagesValue.Count == 1);
+
+        var nameValue = manifest["name"];
+        Assert.IsNotNull(nameValue);
+        Assert.AreEqual($"{PackageName} {PackageVersion}", (string)nameValue);
+
+        var creatorsValue = manifest["creationInfo"]["creators"];
+        Assert.IsNotNull(creatorsValue);
+        Assert.IsTrue(creatorsValue.Count > 0);
+        Assert.IsTrue(((string)creatorsValue[0]).Contains(PackageSuplier));
+
+        string namespaceValue = manifest["documentNamespace"];
+        Assert.IsNotNull(namespaceValue);
+        Assert.IsTrue(namespaceValue.Contains($"{NamespaceBaseUri}/{PackageName}/{PackageVersion}"));
+    }
+
+    [TestMethod]
+    public void Sbom_Generation_Fails_With_NotFound_BuildDropPath()
+    {
+        // Arrange
+        var task = new GenerateSbomTask
+        {
+            BuildDropPath = ".\\non-existent\\path",
+            PackageSupplier = PackageSuplier,
+            PackageName = PackageName,
+            PackageVersion = PackageVersion,
+            NamespaceBaseUri = NamespaceBaseUri,
+            BuildEngine = this.buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void Sbom_Generation_Fails_With_NotFound_BuildComponentPath()
+    {
+        // Arrange
+        var task = new GenerateSbomTask
+        {
+            BuildDropPath = CurrentDirectory,
+            BuildComponentPath = ".\\non-existent\\path",
+            PackageSupplier = PackageSuplier,
+            PackageName = PackageName,
+            PackageVersion = PackageVersion,
+            NamespaceBaseUri = NamespaceBaseUri,
+            BuildEngine = this.buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        Assert.IsFalse(result);
+        Assert.IsFalse(Directory.Exists(ManifestDirectory));
+    }
+
+    [TestMethod]
+    public void Sbom_Generation_Fails_With_NotFound_ExternalDocumentListFile()
+    {
+        // Arrange
+        var task = new GenerateSbomTask
+        {
+            BuildDropPath = CurrentDirectory,
+            ExternalDocumentListFile = ".\\non-existent\\path",
+            PackageSupplier = PackageSuplier,
+            PackageName = PackageName,
+            PackageVersion = PackageVersion,
+            NamespaceBaseUri = NamespaceBaseUri,
+            BuildEngine = this.buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        Assert.IsFalse(result);
+        Assert.IsFalse(Directory.Exists(ManifestDirectory));
+    }
+
+    [TestMethod]
+    public void Sbom_Generation_Fails_With_NotFound_ManifestDirPath()
+    {
+        // Arrange
+        var task = new GenerateSbomTask
+        {
+            BuildDropPath = CurrentDirectory,
+            ManifestDirPath = ".\\non-existent\\path",
+            PackageSupplier = PackageSuplier,
+            PackageName = PackageName,
+            PackageVersion = PackageVersion,
+            NamespaceBaseUri = NamespaceBaseUri,
+            BuildEngine = this.buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        Assert.IsFalse(result);
+        Assert.IsFalse(Directory.Exists(ManifestDirectory));
+    }
+
+    [TestMethod]
+    public void Sbom_Is_Successfully_Generated_With_Component_Path()
+    {
+        // Let's generate a SBOM for the current assembly
+        var sourceDirectory = Path.Combine(CurrentDirectory, "..\\..\\..");
+
+        // Arrange
+        var task = new GenerateSbomTask
+        {
+            BuildDropPath = CurrentDirectory,
+            BuildComponentPath = sourceDirectory,
+            PackageSupplier = PackageSuplier,
+            PackageName = PackageName,
+            PackageVersion = PackageVersion,
+            NamespaceBaseUri = NamespaceBaseUri,
+            BuildEngine = this.buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        Assert.IsTrue(result);
+        Assert.IsTrue(File.Exists(ManifestPath));
+
+        // Read and parse the manifest
+        var manifestContent = File.ReadAllText(ManifestPath);
+        var manifest = JsonConvert.DeserializeObject<dynamic>(manifestContent);
+
+        // Check the manifest has expected values
+        var filesValue = manifest["files"];
+        Assert.IsNotNull(filesValue);
+        Assert.IsTrue(filesValue.Count > 0);
+
+        var packagesValue = manifest["packages"];
+        Assert.IsNotNull(packagesValue);
+        Assert.IsTrue(packagesValue.Count > 1);
+
+        var nameValue = manifest["name"];
+        Assert.IsNotNull(nameValue);
+        Assert.AreEqual($"{PackageName} {PackageVersion}", (string)nameValue);
+
+        var creatorsValue = manifest["creationInfo"]["creators"];
+        Assert.IsNotNull(creatorsValue);
+        Assert.IsTrue(creatorsValue.Count > 0);
+        Assert.IsTrue(((string)creatorsValue[0]).Contains(PackageSuplier));
+
+        string namespaceValue = manifest["documentNamespace"];
+        Assert.IsNotNull(namespaceValue);
+        Assert.IsTrue(namespaceValue.Contains($"{NamespaceBaseUri}/{PackageName}/{PackageVersion}"));
+    }
+
+    [TestMethod]
+    public void Sbom_Is_Successfully_Generated_With_Unique_Namespace_Part_Defined()
+    {
+        var uniqueNamespacePart = Guid.NewGuid().ToString();
+        // Arrange
+        var task = new GenerateSbomTask
+        {
+            BuildDropPath = CurrentDirectory,
+            PackageSupplier = PackageSuplier,
+            PackageName = PackageName,
+            PackageVersion = PackageVersion,
+            NamespaceBaseUri = NamespaceBaseUri,
+            NamespaceUriUniquePart = uniqueNamespacePart,
+            BuildEngine = this.buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert
+        Assert.IsTrue(result);
+        Assert.IsTrue(File.Exists(ManifestPath));
+
+        // Read and parse the manifest
+        var manifestContent = File.ReadAllText(ManifestPath);
+        var manifest = JsonConvert.DeserializeObject<dynamic>(manifestContent);
+
+        // Check the manifest has expected values
+        var filesValue = manifest["files"];
+        Assert.IsNotNull(filesValue);
+        Assert.IsTrue(filesValue.Count > 0);
+
+        var packagesValue = manifest["packages"];
+        Assert.IsNotNull(packagesValue);
+        Assert.IsTrue(packagesValue.Count == 1);
+
+        var nameValue = manifest["name"];
+        Assert.IsNotNull(nameValue);
+        Assert.AreEqual($"{PackageName} {PackageVersion}", (string)nameValue);
+
+        var creatorsValue = manifest["creationInfo"]["creators"];
+        Assert.IsNotNull(creatorsValue);
+        Assert.IsTrue(creatorsValue.Count > 0);
+        Assert.IsTrue(((string)creatorsValue[0]).Contains(PackageSuplier));
+
+        string namespaceValue = manifest["documentNamespace"];
+        Assert.IsNotNull(namespaceValue);
+        Assert.AreEqual($"{NamespaceBaseUri}/{PackageName}/{PackageVersion}/{uniqueNamespacePart}", namespaceValue);
     }
 }

--- a/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskTests.cs
@@ -77,7 +77,8 @@ public class GenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object
+            BuildEngine = this.buildEngine.Object,
+            ManifestInfo = this.sbomSpecification.ToString(),
         };
 
         // Act
@@ -102,7 +103,8 @@ public class GenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object
+            BuildEngine = this.buildEngine.Object,
+            ManifestInfo = this.sbomSpecification.ToString(),
         };
 
         // Act
@@ -126,7 +128,8 @@ public class GenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object
+            BuildEngine = this.buildEngine.Object,
+            ManifestInfo = this.sbomSpecification.ToString(),
         };
 
         // Act
@@ -148,7 +151,8 @@ public class GenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object
+            BuildEngine = this.buildEngine.Object,
+            ManifestInfo = this.sbomSpecification.ToString(),
         };
 
         // Act
@@ -171,7 +175,8 @@ public class GenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object
+            BuildEngine = this.buildEngine.Object,
+            ManifestInfo = this.sbomSpecification.ToString(),
         };
 
         // Act
@@ -194,7 +199,8 @@ public class GenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object
+            BuildEngine = this.buildEngine.Object,
+            ManifestInfo = this.sbomSpecification.ToString(),
         };
 
         // Act
@@ -220,7 +226,8 @@ public class GenerateSbomTaskTests
             PackageName = PackageName,
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
-            BuildEngine = this.buildEngine.Object
+            BuildEngine = this.buildEngine.Object,
+            ManifestInfo = this.sbomSpecification.ToString(),
         };
 
         // Act
@@ -244,7 +251,8 @@ public class GenerateSbomTaskTests
             PackageVersion = PackageVersion,
             NamespaceBaseUri = NamespaceBaseUri,
             NamespaceUriUniquePart = uniqueNamespacePart,
-            BuildEngine = this.buildEngine.Object
+            BuildEngine = this.buildEngine.Object,
+            ManifestInfo = this.sbomSpecification.ToString(),
         };
 
         // Act

--- a/test/Microsoft.Sbom.Targets.Tests/Utility/GeneratedSbomValidator.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/Utility/GeneratedSbomValidator.cs
@@ -28,14 +28,7 @@ internal class GeneratedSbomValidator
         this.sbomSpecification = sbomSpecification;
     }
 
-    internal void AssertSbomIsValid(string manifestPath,
-        string buildDropPath,
-        string expectedPackageName,
-        string expectedPackageVersion,
-        string expectedPackageSupplier,
-        string expectedNamespaceUriBase,
-        string expectedNamespaceUriUniquePart = null,
-        string buildComponentPath = null)
+    internal void AssertSbomIsValid(string manifestPath, string buildDropPath, string expectedPackageName, string expectedPackageVersion, string expectedPackageSupplier, string expectedNamespaceUriBase, string expectedNamespaceUriUniquePart = null, string buildComponentPath = null)
     {
         Assert.IsTrue(File.Exists(manifestPath));
 

--- a/test/Microsoft.Sbom.Targets.Tests/Utility/GeneratedSbomValidator.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/Utility/GeneratedSbomValidator.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Targets.Tests.Utility;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.Utils;
+using Microsoft.Sbom.Contracts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+/// <summary>
+/// This class is used to validate that the generated SBOM has valid fields and data.
+/// </summary>
+#pragma warning disable CA5350 // Suppress Do Not Use Weak Cryptographic Algorithms as we use SHA1 intentionally
+internal class GeneratedSbomValidator
+{
+    private readonly SbomSpecification sbomSpecification;
+
+    public GeneratedSbomValidator(SbomSpecification sbomSpecification)
+    {
+        this.sbomSpecification = sbomSpecification;
+    }
+
+    internal void AssertSbomIsValid(string manifestPath,
+        string buildDropPath,
+        string expectedPackageName,
+        string expectedPackageVersion,
+        string expectedPackageSupplier,
+        string expectedNamespaceUriBase,
+        string expectedNamespaceUriUniquePart = null,
+        string buildComponentPath = null)
+    {
+        Assert.IsTrue(File.Exists(manifestPath));
+
+        // Read and parse the manifest
+        var manifestContent = File.ReadAllText(manifestPath);
+        var manifest = JsonConvert.DeserializeObject<dynamic>(manifestContent);
+
+        if (this.sbomSpecification.Equals(Constants.SPDX22Specification))
+        {
+            // Check the manifest has expected file data
+            var filesValue = manifest["files"];
+            Assert.IsNotNull(filesValue);
+
+            var expectedFilesHashes = this.GetBuildDropFileHashes(buildDropPath);
+            Assert.AreEqual(expectedFilesHashes.Count, filesValue.Count);
+            foreach (var file in filesValue)
+            {
+                var filePath = Path.GetFullPath(Path.Combine(buildDropPath, (string)file["fileName"]));
+                var fileChecksums = file["checksums"];
+                Assert.IsNotNull(fileChecksums);
+
+                foreach (var checksum in fileChecksums)
+                {
+                    var algorithm = (string)checksum["algorithm"];
+                    var hash = (string)checksum["checksumValue"];
+                    Assert.IsNotNull(algorithm);
+                    Assert.IsNotNull(hash);
+
+                    Assert.IsTrue(expectedFilesHashes.ContainsKey(filePath));
+                    Assert.IsTrue(expectedFilesHashes[filePath].ContainsKey(algorithm));
+                    Assert.IsTrue(expectedFilesHashes[filePath][algorithm].Equals(hash, StringComparison.InvariantCultureIgnoreCase));
+                }
+            }
+
+            var packagesValue = manifest["packages"];
+            Assert.IsNotNull(packagesValue);
+            if (string.IsNullOrEmpty(buildComponentPath))
+            {
+                Assert.IsTrue(packagesValue.Count == 1);
+            }
+            else
+            {
+                Assert.IsTrue(packagesValue.Count > 1);
+            }
+
+            var nameValue = manifest["name"];
+            Assert.IsNotNull(nameValue);
+            Assert.AreEqual($"{expectedPackageName} {expectedPackageVersion}", (string)nameValue);
+
+            var creatorsValue = manifest["creationInfo"]["creators"];
+            Assert.IsNotNull(creatorsValue);
+            Assert.IsTrue(creatorsValue.Count > 0);
+            Assert.IsTrue(((string)creatorsValue[0]).Contains(expectedPackageSupplier));
+
+            string namespaceValue = manifest["documentNamespace"];
+            Assert.IsNotNull(namespaceValue);
+
+            if (expectedNamespaceUriUniquePart != null)
+            {
+                Assert.IsTrue(namespaceValue.Equals($"{expectedNamespaceUriBase}/{expectedPackageName}/{expectedPackageVersion}/{expectedNamespaceUriUniquePart}", StringComparison.InvariantCultureIgnoreCase));
+            }
+            else
+            {
+                Assert.IsTrue(namespaceValue.Contains($"{expectedNamespaceUriBase}/{expectedPackageName}/{expectedPackageVersion}", StringComparison.InvariantCultureIgnoreCase));
+            }
+        }
+    }
+
+    private IDictionary<string, IDictionary<string, string>> GetBuildDropFileHashes(string buildDropPath)
+    {
+        var filesHashes = new Dictionary<string, IDictionary<string, string>>();
+
+        // Get all files in the buildDropPath and its subfolders
+        var files = Directory.GetFiles(buildDropPath, "*", SearchOption.AllDirectories)
+            .Where(f => !f.Contains("manifest.spdx.json"))
+            .Select(Path.GetFullPath);
+
+        // Compute hashes for each file.
+        foreach (var filePath in files)
+        {
+            var fileHashes = new Dictionary<string, string>();
+            // Compute hashes for the file.
+            foreach (var hashAlgorithmPair in this.GetListOfHashAlgorithmCreators())
+            {
+                using var stream = File.OpenRead(filePath);
+                using var hashAlgorithmInstance = hashAlgorithmPair.Item2();
+                var hash = hashAlgorithmInstance.ComputeHash(stream);
+                var hashString = BitConverter.ToString(hash).Replace("-", string.Empty);
+                fileHashes.Add(hashAlgorithmPair.Item1, hashString);
+            }
+
+            filesHashes.Add(filePath, fileHashes);
+        }
+
+        return filesHashes;
+    }
+
+    private IList<(string, Func<HashAlgorithm>)> GetListOfHashAlgorithmCreators()
+    {
+        if (this.sbomSpecification.Equals(Constants.SPDX22Specification))
+        {
+            return [("SHA1", SHA1.Create), ("SHA256", SHA256.Create)];
+        }
+
+        return [];
+    }
+}


### PR DESCRIPTION
This PR adds tests for SBOM generation by calling the `GenerateSbomTask.Execute` method.

The tests include valid and invalid cases, and validate the generated SBOM at the end of each test.