### PR TITLE
Add MSBuild properties to our Props file

### DIFF
--- a/src/Microsoft.Sbom.Api/SBOMGenerator.cs
+++ b/src/Microsoft.Sbom.Api/SBOMGenerator.cs
@@ -80,7 +80,7 @@ public class SbomGenerator : ISBOMGenerator
 
         var entityErrors = recorder.Errors.Select(error => error.ToEntityError()).ToList();
 
-        return new SbomGenerationResult(isSuccess, entityErrors);
+        return new SbomGenerationResult(isSuccess, entityErrors, isSuccess ? inputConfiguration.ManifestDirPath.ToString() : null);
     }
 
     /// <inheritdoc />
@@ -120,7 +120,7 @@ public class SbomGenerator : ISBOMGenerator
         // This is the generate workflow
         var result = await generationWorkflow.RunAsync();
 
-        return new SbomGenerationResult(result, new List<EntityError>());
+        return new SbomGenerationResult(result, new List<EntityError>(), result ? inputConfiguration.ManifestDirPath.ToString() : null);
     }
 
     /// <inheritdoc />

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMGenerationResult.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMGenerationResult.cs
@@ -22,7 +22,7 @@ public class SbomGenerationResult
     public IList<EntityError> Errors { get; private set; }
 
     /// <summary>
-    /// The path where the SBOM was generated, if the generation was successful.
+    /// Gets the path where the SBOM was generated, if the generation was successful.
     /// </summary>
     public string? ManifestDirPath { get; private set; }
 

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMGenerationResult.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMGenerationResult.cs
@@ -21,9 +21,15 @@ public class SbomGenerationResult
     /// </summary>
     public IList<EntityError> Errors { get; private set; }
 
-    public SbomGenerationResult(bool isSuccessful, IList<EntityError> errors)
+    /// <summary>
+    /// The path where the SBOM was generated, if the generation was successful.
+    /// </summary>
+    public string? ManifestDirPath { get; private set; }
+
+    public SbomGenerationResult(bool isSuccessful, IList<EntityError> errors, string manifestDirPath = null)
     {
         IsSuccessful = isSuccessful;
         Errors = errors ?? new List<EntityError>();
+        this.ManifestDirPath = manifestDirPath;
     }
 }

--- a/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
+++ b/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
@@ -31,9 +31,6 @@ using Serilog.Events;
 
 public class GenerateSbomTask : Task
 {
-    // TODO it is possible we will want to expose additional arguments, either as required or optional.
-    // Will need to get SDK team/ windows team input on which arguments are necessary.
-
     /// <summary>
     /// The path to the drop directory for which the SBOM will be generated
     /// </summary>
@@ -149,7 +146,6 @@ public class GenerateSbomTask : Task
     {
         try
         {
-            //this.Log.LogWarning($"BuildDropPath: {BuildDropPath}; BuildComponentPath: {BuildComponentPath}; PackageSupplier: {PackageSupplier};\nPackageName: {PackageName}; PackageVersion: {PackageVersion}; NamespaceBaseUri: {NamespaceBaseUri}; NamespaceUriUniquePart: {NamespaceUriUniquePart};\nExternalDocumentListFile: {ExternalDocumentListFile}; {FetchLicenseInformation}; EnablePackageMetadataParsing: {EnablePackageMetadataParsing}; {Verbosity}; ManifestInfo: {ManifestInfo}; DeleteManifestDirIfPresent: {DeleteManifestDirIfPresent}; ManifestDirPath: {ManifestDirPath};");
             // Set other configurations. The GenerateSBOMAsync() already sanitizes and checks for
             // a valid namespace URI and generates a random guid for NamespaceUriUniquePart if
             // one is not provided.

--- a/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
+++ b/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
@@ -149,6 +149,7 @@ public class GenerateSbomTask : Task
     {
         try
         {
+            //this.Log.LogWarning($"BuildDropPath: {BuildDropPath}; BuildComponentPath: {BuildComponentPath}; PackageSupplier: {PackageSupplier};\nPackageName: {PackageName}; PackageVersion: {PackageVersion}; NamespaceBaseUri: {NamespaceBaseUri}; NamespaceUriUniquePart: {NamespaceUriUniquePart};\nExternalDocumentListFile: {ExternalDocumentListFile}; {FetchLicenseInformation}; EnablePackageMetadataParsing: {EnablePackageMetadataParsing}; {Verbosity}; ManifestInfo: {ManifestInfo}; DeleteManifestDirIfPresent: {DeleteManifestDirIfPresent}; ManifestDirPath: {ManifestDirPath};");
             // Set other configurations. The GenerateSBOMAsync() already sanitizes and checks for
             // a valid namespace URI and generates a random guid for NamespaceUriUniquePart if
             // one is not provided.

--- a/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
+++ b/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Sbom.Targets;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.IO;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -173,7 +174,7 @@ public class GenerateSbomTask : Task
                 externalDocumentReferenceListFile: this.ExternalDocumentListFile)).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
 
-            SbomPath = "path/to/sbom";
+            SbomPath = !string.IsNullOrWhiteSpace(result.ManifestDirPath) ? Path.GetFullPath(result.ManifestDirPath) : null;
             return result.IsSuccessful;
         }
         catch (Exception e)

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
@@ -2,26 +2,27 @@
 
   <PropertyGroup>
     <GenerateSbomTask_TFM Condition=" '$(TargetFramework)' == 'net6.0' ">net6.0</GenerateSbomTask_TFM>
-      <GenerateSbomTask_TFM Condition=" '$(TargetFramework)' == 'net8.0' ">net8.0</GenerateSbomTask_TFM>
+    <GenerateSbomTask_TFM Condition=" '$(TargetFramework)' == 'net8.0' ">net8.0</GenerateSbomTask_TFM>
   </PropertyGroup>
   <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbomTask" AssemblyFile="$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbomTask_TFM)\Microsoft.Sbom.Targets.dll" />
 
   <PropertyGroup>
+        <GenerateSBOM Condition=" '$(GenerateSBOM)' == '' ">false</GenerateSBOM>
         <!-- TODO in practice these will default to existing nuget props instead of these test values.
             Need to consult with .NET SDK/ PM team for which existing props will make sense as defaults. -->
-        <SbomGenerationBuildDropPath>C:\Users\gustavoca\Repos\github\sbom-test\src\GenerateSBOMTest\GenerateSBOMTest\bin\Debug\net8.0</SbomGenerationBuildDropPath>
-        <SbomGenerationBuildComponentPath>$(MSBuildProjectDirectory)</SbomGenerationBuildComponentPath>
-        <SbomGenerationPackageSupplier>test-supplier</SbomGenerationPackageSupplier>
-        <SbomGenerationPackageName>test-name</SbomGenerationPackageName>
-        <SbomGenerationPackageVersion>1.0.0</SbomGenerationPackageVersion>
-        <SbomGenerationNamespaceBaseUri>http://spdx.org/spdxdocs/$(SbomGenerationPackageName)</SbomGenerationNamespaceBaseUri>
-        <SbomGenerationNamespaceUriUniquePart></SbomGenerationNamespaceUriUniquePart>
-        <SbomGenerationExternalDocumentReferenceListFile></SbomGenerationExternalDocumentReferenceListFile>
-        <SbomGenerationFetchLicenseInformation>false</SbomGenerationFetchLicenseInformation>
-        <SbomGenerationEnablePackageMetadataParsing>false</SbomGenerationEnablePackageMetadataParsing>
-        <SbomGenerationVerbosity>LogAlways</SbomGenerationVerbosity>
+        <SbomGenerationBuildDropPath Condition=" '$(SbomGenerationBuildDropPath)' == '' ">$(OutDir)</SbomGenerationBuildDropPath>
+        <SbomGenerationBuildComponentPath Condition=" '$(SbomGenerationBuildComponentPath)' == '' ">$(MSBuildProjectDirectory)</SbomGenerationBuildComponentPath>
+        <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) != '' ">$(Authors)</SbomGenerationPackageSupplier>
+        <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) == '' ">$(AssemblyName)</SbomGenerationPackageSupplier>
+        <SbomGenerationPackageName Condition=" '$(SbomGenerationPackageName)' == '' And $(PackageId) != '' ">$(PackageId)</SbomGenerationPackageName>
+        <SbomGenerationPackageName Condition=" '$(SbomGenerationPackageName)' == '' And $(PackageId) == '' ">$(AssemblyName)</SbomGenerationPackageName>
+        <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(Version) != '' ">$(Version)</SbomGenerationPackageVersion>
+        <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(PackageId) == '' ">1.0.0</SbomGenerationPackageVersion>
+        <SbomGenerationNamespaceBaseUri Condition=" '$(SbomGenerationNamespaceBaseUri)' == '' ">http://spdx.org/spdxdocs/$(SbomGenerationPackageName)"</SbomGenerationNamespaceBaseUri>
+        <SbomGenerationFetchLicenseInformation Condition=" '$(SbomGenerationFetchLicenseInformation)' == '' ">false</SbomGenerationFetchLicenseInformation>
+        <SbomGenerationEnablePackageMetadataParsing Condition=" '$(SbomGenerationEnablePackageMetadataParsing)' == '' ">false</SbomGenerationEnablePackageMetadataParsing>
+        <SbomGenerationVerbosity Condition=" '$(SbomGenerationVerbosity)' == '' ">LogAlways</SbomGenerationVerbosity>
         <SbomGenerationManifestInfo Condition=" '$(SbomGenerationManifestInfo)' == '' ">SPDX:2.2</SbomGenerationManifestInfo>
-        <SbomGenerationDeleteManifestDirIfPresent>true</SbomGenerationDeleteManifestDirIfPresent>
-        <SbomGenerationManifestDirPath></SbomGenerationManifestDirPath>
+        <SbomGenerationDeleteManifestDirIfPresent Condition=" '$(SbomGenerationDeleteManifestDirIfPresent)' == '' ">true</SbomGenerationDeleteManifestDirIfPresent>
     </PropertyGroup>
 </Project>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
@@ -10,7 +10,7 @@
         <SbomGenerationPackageName Condition=" '$(SbomGenerationPackageName)' == '' And $(PackageId) != '' ">$(PackageId)</SbomGenerationPackageName>
         <SbomGenerationPackageName Condition=" '$(SbomGenerationPackageName)' == '' And $(PackageId) == '' ">$(AssemblyName)</SbomGenerationPackageName>
         <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(Version) != '' ">$(Version)</SbomGenerationPackageVersion>
-        <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(PackageId) == '' ">1.0.0</SbomGenerationPackageVersion>
+        <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(Version) == '' ">1.0.0</SbomGenerationPackageVersion>
         <SbomGenerationNamespaceBaseUri Condition=" '$(SbomGenerationNamespaceBaseUri)' == '' ">http://spdx.org/spdxdocs/$(SbomGenerationPackageName)"</SbomGenerationNamespaceBaseUri>
         <SbomGenerationFetchLicenseInformation Condition=" '$(SbomGenerationFetchLicenseInformation)' == '' ">false</SbomGenerationFetchLicenseInformation>
         <SbomGenerationEnablePackageMetadataParsing Condition=" '$(SbomGenerationEnablePackageMetadataParsing)' == '' ">false</SbomGenerationEnablePackageMetadataParsing>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
@@ -1,11 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <GenerateSbomTask_TFM Condition=" '$(TargetFramework)' == 'net6.0' ">net6.0</GenerateSbomTask_TFM>
-    <GenerateSbomTask_TFM Condition=" '$(TargetFramework)' == 'net8.0' ">net8.0</GenerateSbomTask_TFM>
-  </PropertyGroup>
-  <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbomTask" AssemblyFile="$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbomTask_TFM)\Microsoft.Sbom.Targets.dll" />
-
   <PropertyGroup>
         <GenerateSBOM Condition=" '$(GenerateSBOM)' == '' ">false</GenerateSBOM>
         <!-- TODO in practice these will default to existing nuget props instead of these test values.

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
@@ -4,7 +4,6 @@
         <!-- TODO in practice these will default to existing nuget props instead of these test values.
             Need to consult with .NET SDK/ PM team for which existing props will make sense as defaults. -->
         <SbomGenerationBuildDropPath Condition=" '$(SbomGenerationBuildDropPath)' == '' ">$(OutDir)</SbomGenerationBuildDropPath>
-        <SbomGenerationManifestDirPath Condition=" '$(SbomGenerationManifestDirPath)' == '' ">$(SbomGenerationBuildDropPath)</SbomGenerationManifestDirPath>
         <SbomGenerationBuildComponentPath Condition=" '$(SbomGenerationBuildComponentPath)' == '' ">$(MSBuildProjectDirectory)</SbomGenerationBuildComponentPath>
         <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) != '' ">$(Authors)</SbomGenerationPackageSupplier>
         <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) == '' ">$(AssemblyName)</SbomGenerationPackageSupplier>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.props
@@ -4,6 +4,7 @@
         <!-- TODO in practice these will default to existing nuget props instead of these test values.
             Need to consult with .NET SDK/ PM team for which existing props will make sense as defaults. -->
         <SbomGenerationBuildDropPath Condition=" '$(SbomGenerationBuildDropPath)' == '' ">$(OutDir)</SbomGenerationBuildDropPath>
+        <SbomGenerationManifestDirPath Condition=" '$(SbomGenerationManifestDirPath)' == '' ">$(SbomGenerationBuildDropPath)</SbomGenerationManifestDirPath>
         <SbomGenerationBuildComponentPath Condition=" '$(SbomGenerationBuildComponentPath)' == '' ">$(MSBuildProjectDirectory)</SbomGenerationBuildComponentPath>
         <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) != '' ">$(Authors)</SbomGenerationPackageSupplier>
         <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) == '' ">$(AssemblyName)</SbomGenerationPackageSupplier>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -11,7 +11,7 @@
   <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbomTask" AssemblyFile="$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbomTask_TFM)\Microsoft.Sbom.Targets.dll" />
   <Import Project="C:\Users\gustavoca\Repos\github\sbom-tool\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.props" />
   
-  <Target Name="GenerateSbom" AfterTargets="Build">
+  <Target Name="GenerateSbomTarget" AfterTargets="Build" Condition=" '$(GenerateSBOM)' ==  'true'">
         <GenerateSbomTask
             BuildDropPath="$(SbomGenerationBuildDropPath)"
             BuildComponentPath="$(SbomGenerationBuildComponentPath)"

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -8,10 +8,14 @@
         We will need to discuss with the .NET SDK team if they want this target to be automatically included after any
         target and if so, which one. They likely know of a nuget packaging target that it would make sense to hook this in with.-->
 
+  <PropertyGroup>
+    <GenerateSbomTask_TFM Condition=" '$(TargetFramework)' == 'net6.0' ">net6.0</GenerateSbomTask_TFM>
+    <GenerateSbomTask_TFM Condition=" '$(TargetFramework)' == 'net8.0' ">net8.0</GenerateSbomTask_TFM>
+  </PropertyGroup>
   <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbomTask" AssemblyFile="$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbomTask_TFM)\Microsoft.Sbom.Targets.dll" />
-  <Import Project="C:\Users\gustavoca\Repos\github\sbom-tool\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.props" />
-  
-  <Target Name="GenerateSbomTarget" AfterTargets="Build" Condition=" '$(GenerateSBOM)' ==  'true'">
+  <Import Project="$(MSBuildThisFileDirectory)\Microsoft.Sbom.Targets.props" />
+
+  <Target Name="GenerateSbomTarget" AfterTargets="Build" Condition=" '$(GenerateSBOM)' ==  'true' And '$(MSBuildRuntimeType)' == 'Core'">
         <GenerateSbomTask
             BuildDropPath="$(SbomGenerationBuildDropPath)"
             BuildComponentPath="$(SbomGenerationBuildComponentPath)"


### PR DESCRIPTION
We want to use as much as possible values provided by MSBuild and .NET into our properties. Also, we want to return the path to the _manifest folder in our task.

# Change details
- Add the field `ManifestDirPath` to the `SbomGenerationResult` class, hence we can return its value to the caller of the task.
- Use the property `GenerateSBOM` for enabling or disabling the SBOM generation.
- Don't run call the task if the MSBuild version being used is not the one for .NET Core.
- Use MSBuild and .NET properties as default values for our properties as follows:
    - `OutDir` for `SbomGenerationBuildDropPath`.
    - `MSBuildProjectDirectory` for `SbomGenerationBuildComponentPath `
    - `Authors` or `AssemblyName` for `SbomGenerationPackageSupplier`.
    - `PackageId` or `AssemblyName` for `SbomGenerationPackageName`.
    - `Version` or `1.0.0` for `SbomGenerationPackageVersion`.
    