### PR TITLE
Include SBOM Files in user's NuGet packages

### DIFF
--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -16,23 +16,31 @@
   <Import Project="$(MSBuildThisFileDirectory)\Microsoft.Sbom.Targets.props" />
 
   <Target Name="GenerateSbomTarget" AfterTargets="Build" Condition=" '$(GenerateSBOM)' ==  'true' And '$(MSBuildRuntimeType)' == 'Core'">
-        <GenerateSbomTask
-            BuildDropPath="$(SbomGenerationBuildDropPath)"
-            BuildComponentPath="$(SbomGenerationBuildComponentPath)"
-            PackageSupplier="$(SbomGenerationPackageSupplier)"
-            PackageName="$(SbomGenerationPackageName)"
-            PackageVersion="$(SbomGenerationPackageVersion)"
-            NamespaceBaseUri="$(SbomGenerationNamespaceBaseUri)"
-            NamespaceUriUniquePart="$(SbomGenerationNamespaceUriUniquePart)"
-            ExternalDocumentListFile="$(SbomGenerationExternalDocumentReferenceListFile)"
-            FetchLicenseInformation="$(SbomGenerationFetchLicenseInformation)"
-            EnablePackageMetadataParsing="$(SbomGenerationEnablePackageMetadataParsing)"
-            Verbosity="$(SbomGenerationVerbosity)"
-            ManifestInfo="$(SbomGenerationManifestInfo)"
-            DeleteManifestDirIfPresent="$(SbomGenerationDeleteManifestDirIfPresent)"
-            ManifestDirPath="$(SbomGenerationManifestDirPath)">
-            <Output TaskParameter="SbomPath" PropertyName="SbomPathResult" />
-        </GenerateSbomTask> 
-        <Message Importance="High" Text="Task result: $(SbomPathResult)" />
-    </Target>
+    <GenerateSbomTask
+        BuildDropPath="$(SbomGenerationBuildDropPath)"
+        BuildComponentPath="$(SbomGenerationBuildComponentPath)"
+        PackageSupplier="$(SbomGenerationPackageSupplier)"
+        PackageName="$(SbomGenerationPackageName)"
+        PackageVersion="$(SbomGenerationPackageVersion)"
+        NamespaceBaseUri="$(SbomGenerationNamespaceBaseUri)"
+        NamespaceUriUniquePart="$(SbomGenerationNamespaceUriUniquePart)"
+        ExternalDocumentListFile="$(SbomGenerationExternalDocumentReferenceListFile)"
+        FetchLicenseInformation="$(SbomGenerationFetchLicenseInformation)"
+        EnablePackageMetadataParsing="$(SbomGenerationEnablePackageMetadataParsing)"
+        Verbosity="$(SbomGenerationVerbosity)"
+        ManifestInfo="$(SbomGenerationManifestInfo)"
+        DeleteManifestDirIfPresent="$(SbomGenerationDeleteManifestDirIfPresent)"
+        ManifestDirPath="$(SbomGenerationManifestDirPath)">
+        <Output TaskParameter="SbomPath" PropertyName="SbomPathResult" />
+    </GenerateSbomTask> 
+    <Message Importance="High" Text="Task result: $(SbomPathResult)" />
+
+    <!-- Include the generated SBOM contents within the consumer's nuget package -->
+    <ItemGroup >
+      <Content Include="$(SbomPathResult)\**">
+        <Pack>true</Pack>
+        <PackagePath>_manifest</PackagePath>
+      </Content>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Add logic for copying over the generated SBOM files into the consumer's NuGet packages when doing a "dotnet pack"