### PR TITLE
make task target dotnet6

### DIFF
--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.csproj
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Sbom.Targets</AssemblyName>
-    <TargetFrameworks>net8.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <IsPublishable>true</IsPublishable>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
Only the unit tests cannot run with .NET 6, but the task can still target .NET 6. 

# Validation
I have tested it locally and it works.

This is how the Nuget package looks now:
![image](https://github.com/gustavoaca1997/sbom-tool/assets/27758316/cc676a06-2ccc-404b-a975-a51f8d31060e)

And the successful build:
![image](https://github.com/gustavoaca1997/sbom-tool/assets/27758316/358acef3-3265-43b2-b142-b56280191e75)

