### PR TITLE
Remove unrooted checks

### DIFF
--- a/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
+++ b/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
@@ -148,7 +148,7 @@ public class GenerateSbomTask : Task
         try
         {
             // Validate required args and args that take paths as input.
-            if (!ValidateAndSanitizeRequiredParams() || !ValidateRootedPaths() || !ValidateAndSanitizeNamespaceUriUniquePart())
+            if (!ValidateAndSanitizeRequiredParams() || !ValidateAndSanitizeNamespaceUriUniquePart())
             {
                 return false;
             }
@@ -238,43 +238,6 @@ public class GenerateSbomTask : Task
         this.PackageVersion = Remove_Spaces_Tabs_Newlines(this.PackageVersion);
         this.NamespaceBaseUri = this.NamespaceBaseUri.Trim();
         this.BuildDropPath = this.BuildDropPath.Trim();
-
-        return true;
-    }
-
-    /// <summary>
-    /// Ensure all arguments that accept paths are rooted.
-    /// </summary>
-    /// <returns></returns>
-    private bool ValidateRootedPaths()
-    {
-        if (!Path.IsPathRooted(this.BuildDropPath))
-        {
-            Log.LogError($"SBOM generation failed: Unrooted path detected. Please specify a full path for {nameof(this.BuildDropPath)}. " +
-                $"Current value is {this.BuildDropPath}");
-            return false;
-        }
-
-        if (!string.IsNullOrWhiteSpace(this.BuildComponentPath) && !Path.IsPathRooted(this.BuildComponentPath))
-        {
-            Log.LogError($"SBOM generation failed: Unrooted path detected. Please specify a full path for {nameof(this.BuildComponentPath)}. " +
-                $"Current value is {this.BuildComponentPath}");
-            return false;
-        }
-
-        if (!string.IsNullOrWhiteSpace(this.ManifestDirPath) && !Path.IsPathRooted(this.ManifestDirPath))
-        {
-            Log.LogError($"SBOM generation failed: Unrooted path detected. Please specify a full path for {nameof(this.ManifestDirPath)}. " +
-                $"Current value is {this.ManifestDirPath}");
-            return false;
-        }
-
-        if (!string.IsNullOrWhiteSpace(this.ExternalDocumentListFile) && !Path.IsPathRooted(this.ExternalDocumentListFile))
-        {
-            Log.LogError($"SBOM generation failed: Unrooted path detected. Please specify a full path for {nameof(this.ExternalDocumentListFile)}. " +
-                $"Current value is {this.ExternalDocumentListFile}");
-            return false;
-        }
 
         return true;
     }

--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSBomTaskInputTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSBomTaskInputTests.cs
@@ -185,49 +185,6 @@ public abstract class AbstractGenerateSBomTaskInputTests
     }
 
     /// <summary>
-    /// Test for ensuring the GenerateSbomTask fails when relative paths are
-    /// provided for all path arguments, which includes BuildDroppath, BuildComponentPath,
-    /// ManifestDirPath, and ExternalDocumentListFile
-    /// </summary>
-    [TestMethod]
-    [DynamicData(nameof(GetUnrootedPathTestData), DynamicDataSourceType.Method)]
-    public void Sbom_Fails_With_Unrooted_Paths(
-        string buildDropPath,
-        string buildComponentPath,
-        string manifestDirPath,
-        string externalDocumentListFile)
-    {
-        // Arrange.
-        var task = new GenerateSbomTask
-        {
-            BuildDropPath = buildDropPath,
-            PackageSupplier = PackageSupplier,
-            PackageName = PackageName,
-            PackageVersion = PackageVersion,
-            NamespaceBaseUri = NamespaceBaseUri,
-            BuildComponentPath = buildComponentPath,
-            ManifestDirPath = manifestDirPath,
-            ExternalDocumentListFile = externalDocumentListFile,
-            ManifestInfo = this.SbomSpecification.ToString(),
-            BuildEngine = this.buildEngine.Object
-        };
-
-        // Act
-        var result = task.Execute();
-
-        // Assert
-        Assert.IsFalse(result);
-    }
-
-    private static IEnumerable<object[]> GetUnrootedPathTestData()
-    {
-        yield return new object[] { Path.Combine("..", ".."), BuildComponentPath, DefaultManifestDirectory, ExternalDocumentListFile };
-        yield return new object[] { CurrentDirectory, Path.Combine("..", ".."), DefaultManifestDirectory, ExternalDocumentListFile };
-        yield return new object[] { CurrentDirectory, BuildComponentPath, Path.Combine("..", ".."), ExternalDocumentListFile };
-        yield return new object[] { CurrentDirectory, BuildComponentPath, DefaultManifestDirectory, Path.Combine("..", "..") };
-    }
-
-    /// <summary>
     /// Test for ensuring GenerateSbomTask assigns a defualt Verbosity
     /// level when null input is provided.
     /// </summary>


### PR DESCRIPTION
These checks broke the possibility of not specifying explicitly the paths by the user. One workaround would be to transform the paths into Full Paths, which will make the check pointless since full paths will always be rooted.