### PR TITLE
Fix ubuntu tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+      # Remove before merging into main
+      - users/gustavoca/net-sdk-sbom-tool
   pull_request:
     branches:
       - main
+      # Remove before merging into main
+      - users/gustavoca/net-sdk-sbom-tool
 
 permissions:
   contents: read

--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
@@ -29,7 +29,7 @@ public abstract class AbstractGenerateSbomTaskTests
     internal string ManifestPath;
     internal GeneratedSbomValidator GeneratedSbomValidator;
 
-    internal string SbomSpecificationDirectoryName => $"{this.SbomSpecification.Name}_{this.SbomSpecification.Version}";
+    internal string SbomSpecificationDirectoryName => $"{this.SbomSpecification.Name}_{this.SbomSpecification.Version}".ToLowerInvariant();
 
     [TestInitialize]
     public void Startup()


### PR DESCRIPTION
Ubuntu tests were failing because Linux is case sensitive while Windows is case unsensitive. That's why the paths were not being found.